### PR TITLE
Permit custom image or shape instead of the plus sign; also rotation angle is public property

### DIFF
--- a/Example/LiquidFloatingActionButton/ViewController.swift
+++ b/Example/LiquidFloatingActionButton/ViewController.swift
@@ -37,6 +37,36 @@ public class CustomCell : LiquidFloatingCell {
     }
 }
 
+public class CustomDrawingActionButton: LiquidFloatingActionButton {
+    
+    override public func createPlusLayer(frame: CGRect) -> CAShapeLayer {
+        
+        let plusLayer = CAShapeLayer()
+        plusLayer.lineCap = kCALineCapRound
+        plusLayer.strokeColor = UIColor.whiteColor().CGColor
+        plusLayer.lineWidth = 3.0
+        
+        let w = frame.width
+        let h = frame.height
+        
+        let points = [
+            (CGPoint(x: w * 0.25, y: h * 0.35), CGPoint(x: w * 0.75, y: h * 0.35)),
+            (CGPoint(x: w * 0.25, y: h * 0.5), CGPoint(x: w * 0.75, y: h * 0.5)),
+            (CGPoint(x: w * 0.25, y: h * 0.65), CGPoint(x: w * 0.75, y: h * 0.65))
+        ]
+        
+        let path = UIBezierPath()
+        for (start, end) in points {
+            path.moveToPoint(start)
+            path.addLineToPoint(end)
+        }
+        
+        plusLayer.path = path.CGPath
+        
+        return plusLayer
+    }
+}
+
 class ViewController: UIViewController, LiquidFloatingActionButtonDataSource, LiquidFloatingActionButtonDelegate {
     
     var cells: [LiquidFloatingCell] = []
@@ -44,10 +74,11 @@ class ViewController: UIViewController, LiquidFloatingActionButtonDataSource, Li
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
 //        self.view.backgroundColor = UIColor(red: 55 / 255.0, green: 55 / 255.0, blue: 55 / 255.0, alpha: 1.0)
         // Do any additional setup after loading the view, typically from a nib.
         let createButton: (CGRect, LiquidFloatingActionButtonAnimateStyle) -> LiquidFloatingActionButton = { (frame, style) in
-            let floatingActionButton = LiquidFloatingActionButton(frame: frame)
+            let floatingActionButton = CustomDrawingActionButton(frame: frame)
             floatingActionButton.animateStyle = style
             floatingActionButton.dataSource = self
             floatingActionButton.delegate = self
@@ -68,6 +99,9 @@ class ViewController: UIViewController, LiquidFloatingActionButtonDataSource, Li
         
         let floatingFrame = CGRect(x: self.view.frame.width - 56 - 16, y: self.view.frame.height - 56 - 16, width: 56, height: 56)
         let bottomRightButton = createButton(floatingFrame, .Up)
+        
+        let image = UIImage(named: "ic_art")
+        bottomRightButton.image = image
         
         let floatingFrame2 = CGRect(x: 16, y: 16, width: 56, height: 56)
         let topLeftButton = createButton(floatingFrame2, .Down)

--- a/Pod/Classes/LiquidFloatingActionButton.swift
+++ b/Pod/Classes/LiquidFloatingActionButton.swift
@@ -52,23 +52,29 @@ public class LiquidFloatingActionButton : UIView {
             return !baseView.openingCells.isEmpty
         }
     }
-    public var isClosed: Bool {
-        get {
-            return plusRotation == 0
-        }
-    }
-
+    public private(set) var isClosed: Bool = true
+    
     @IBInspectable public var color: UIColor = UIColor(red: 82 / 255.0, green: 112 / 255.0, blue: 235 / 255.0, alpha: 1.0) {
         didSet {
             baseView.color = color
         }
     }
+    
+    @IBInspectable public var image: UIImage? {
+        didSet {
+            if image != nil {
+                plusLayer.contents = image!.CGImage
+                plusLayer.path = nil
+            }
+        }
+    }
+    
+    @IBInspectable public var rotationDegrees: CGFloat = 45.0
 
-    private let plusLayer   = CAShapeLayer()
+    private var plusLayer   = CAShapeLayer()
     private let circleLayer = CAShapeLayer()
-
+    
     private var touching = false
-    private var plusRotation: CGFloat = 0
 
     private var baseView = CircleLiquidBaseView()
     private let liquidView = UIView()
@@ -103,9 +109,10 @@ public class LiquidFloatingActionButton : UIView {
 
     // open all cells
     public func open() {
+        
         // rotate plus icon
-        self.plusLayer.addAnimation(plusKeyframe(true), forKey: "plusRot")
-        self.plusRotation = CGFloat(M_PI * 0.25) // 45 degree
+        CATransaction.setAnimationDuration(0.8)
+        self.plusLayer.transform = CATransform3DMakeRotation((CGFloat(M_PI) * rotationDegrees) / 180, 0, 0, 1)
 
         let cells = cellArray()
         for cell in cells {
@@ -113,28 +120,48 @@ public class LiquidFloatingActionButton : UIView {
         }
 
         self.baseView.open(cells)
-        setNeedsDisplay()
+        
+        self.isClosed = false
     }
 
     // close all cells
     public func close() {
+        
         // rotate plus icon
-        self.plusLayer.addAnimation(plusKeyframe(false), forKey: "plusRot")
-        self.plusRotation = 0
+        CATransaction.setAnimationDuration(0.8)
+        self.plusLayer.transform = CATransform3DMakeRotation(0, 0, 0, 1)
     
         self.baseView.close(cellArray())
-        setNeedsDisplay()
+        
+        self.isClosed = true
     }
 
     // MARK: draw icon
     public override func drawRect(rect: CGRect) {
         drawCircle()
         drawShadow()
-        drawPlus(plusRotation)
+    }
+    
+    /// create, configure & draw the plus layer (override and create your own shape in subclass!)
+    public func createPlusLayer(frame: CGRect) -> CAShapeLayer {
+        
+        // draw plus shape
+        let plusLayer = CAShapeLayer()
+        plusLayer.lineCap = kCALineCapRound
+        plusLayer.strokeColor = UIColor.whiteColor().CGColor
+        plusLayer.lineWidth = 3.0
+        
+        let path = UIBezierPath()
+        path.moveToPoint(CGPoint(x: frame.width * internalRadiusRatio, y: frame.height * 0.5))
+        path.addLineToPoint(CGPoint(x: frame.width * (1 - internalRadiusRatio), y: frame.height * 0.5))
+        path.moveToPoint(CGPoint(x: frame.width * 0.5, y: frame.height * internalRadiusRatio))
+        path.addLineToPoint(CGPoint(x: frame.width * 0.5, y: frame.height * (1 - internalRadiusRatio)))
+        
+        plusLayer.path = path.CGPath
+        return plusLayer
     }
     
     private func drawCircle() {
-        self.circleLayer.frame = CGRect(origin: CGPointZero, size: self.frame.size)
         self.circleLayer.cornerRadius = self.frame.width * 0.5
         self.circleLayer.masksToBounds = true
         if touching && responsible {
@@ -144,59 +171,12 @@ public class LiquidFloatingActionButton : UIView {
         }
     }
     
-    private func drawPlus(rotation: CGFloat) {
-        plusLayer.frame = CGRect(origin: CGPointZero, size: self.frame.size)
-        plusLayer.lineCap = kCALineCapRound
-        plusLayer.strokeColor = UIColor.whiteColor().CGColor // TODO: customizable
-        plusLayer.lineWidth = 3.0
-
-        plusLayer.path = pathPlus(rotation).CGPath
-    }
-    
     private func drawShadow() {
         if enableShadow {
             circleLayer.appendShadow()
         }
     }
     
-    // draw button plus or close face
-    private func pathPlus(rotation: CGFloat) -> UIBezierPath {
-        let radius = self.frame.width * internalRadiusRatio * 0.5
-        let center = self.center.minus(self.frame.origin)
-        let points = [
-            CGMath.circlePoint(center, radius: radius, rad: rotation),
-            CGMath.circlePoint(center, radius: radius, rad: CGFloat(M_PI_2) + rotation),
-            CGMath.circlePoint(center, radius: radius, rad: CGFloat(M_PI_2) * 2 + rotation),
-            CGMath.circlePoint(center, radius: radius, rad: CGFloat(M_PI_2) * 3 + rotation)
-        ]
-        let path = UIBezierPath()
-        path.moveToPoint(points[0])
-        path.addLineToPoint(points[2])
-        path.moveToPoint(points[1])
-        path.addLineToPoint(points[3])
-        return path
-    }
-    
-    private func plusKeyframe(closed: Bool) -> CAKeyframeAnimation {
-        let paths = closed ? [
-                pathPlus(CGFloat(M_PI * 0)),
-                pathPlus(CGFloat(M_PI * 0.125)),
-                pathPlus(CGFloat(M_PI * 0.25)),
-        ] : [
-                pathPlus(CGFloat(M_PI * 0.25)),
-                pathPlus(CGFloat(M_PI * 0.125)),
-                pathPlus(CGFloat(M_PI * 0)),
-        ]
-        let anim = CAKeyframeAnimation(keyPath: "path")
-        anim.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-        anim.values = paths.map { $0.CGPath }
-        anim.duration = 0.5
-        anim.removedOnCompletion = true
-        anim.fillMode = kCAFillModeForwards
-        anim.delegate = self
-        return anim
-    }
-
     // MARK: Events
     public override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
         self.touching = true
@@ -241,7 +221,11 @@ public class LiquidFloatingActionButton : UIView {
         addSubview(liquidView)
         
         liquidView.layer.addSublayer(circleLayer)
+        circleLayer.frame = liquidView.layer.bounds
+        
+        plusLayer = createPlusLayer(circleLayer.bounds)
         circleLayer.addSublayer(plusLayer)
+        plusLayer.frame = circleLayer.bounds
     }
 
     private func didTapped() {


### PR DESCRIPTION
Following changes:
- changed the animation of the plus sign from "path" keyframe animation to rotation transform
- rotation angle is now a public property of LiquidFloatingActionButton (default is 45 degrees)
- the layer creation method is now public, so the client code can subclass LiquidFloatingActionButton and override it to draw in the layer
- an image property was added to LiquidFloatingActionButton; if set, the image will be drawn into the "plus layer" instead of path

I modified the example project to reflect my changes, now the upper-left button has a custom drawing and the lower-right button has an image.
